### PR TITLE
Add Spotify integration scaffolding and UI

### DIFF
--- a/src/app/api/spotify/audio-features/route.ts
+++ b/src/app/api/spotify/audio-features/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest } from "next/server";
+import { respondWithSpotify, mockAudioFeatures, mockAudioFeaturesList } from "@/lib/spotify/routes";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const ids = req.nextUrl.searchParams.get("ids");
+  const endpoint = ids ? `/audio-features?ids=${ids}` : "/audio-features";
+  const mock = ids ? mockAudioFeaturesList() : mockAudioFeatures();
+  return respondWithSpotify(endpoint, mock);
+}

--- a/src/app/api/spotify/auth/route.ts
+++ b/src/app/api/spotify/auth/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+import { buildAuthUrl } from "@/lib/spotify/auth";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const url = buildAuthUrl("portfolio-spotify");
+  return NextResponse.json({ url });
+}

--- a/src/app/api/spotify/callback/route.ts
+++ b/src/app/api/spotify/callback/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { exchangeCodeForToken, readStateFromRequest, setRefreshToken } from "@/lib/spotify/auth";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const code = req.nextUrl.searchParams.get("code");
+  const state = readStateFromRequest(req);
+  if (!code) {
+    return NextResponse.json({ error: "Missing code" }, { status: 400 });
+  }
+  const token = await exchangeCodeForToken(code);
+  if (token?.refresh_token) {
+    setRefreshToken(token.refresh_token);
+  }
+  return NextResponse.json({
+    receivedState: state,
+    accessToken: token?.access_token ?? null,
+    expiresIn: token?.expires_in ?? null,
+  });
+}

--- a/src/app/api/spotify/now-playing/route.ts
+++ b/src/app/api/spotify/now-playing/route.ts
@@ -1,0 +1,7 @@
+import { respondWithSpotify, mockNowPlayingData } from "@/lib/spotify/routes";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return respondWithSpotify("/me/player/currently-playing", mockNowPlayingData());
+}

--- a/src/app/api/spotify/playlist/route.ts
+++ b/src/app/api/spotify/playlist/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest } from "next/server";
+import { respondWithSpotify, mockPlaylistList } from "@/lib/spotify/routes";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const id = req.nextUrl.searchParams.get("id");
+  const endpoint = id ? `/playlists/${id}` : "/me/playlists";
+  const mock = id ? mockPlaylistList()[0] : mockPlaylistList();
+  return respondWithSpotify(endpoint, mock);
+}

--- a/src/app/api/spotify/recently-played/route.ts
+++ b/src/app/api/spotify/recently-played/route.ts
@@ -1,0 +1,7 @@
+import { respondWithSpotify, mockRecentlyPlayed } from "@/lib/spotify/routes";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return respondWithSpotify("/me/player/recently-played?limit=20", mockRecentlyPlayed);
+}

--- a/src/app/api/spotify/refresh/route.ts
+++ b/src/app/api/spotify/refresh/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+import { refreshAccessToken } from "@/lib/spotify/auth";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const token = await refreshAccessToken();
+  if (!token) return NextResponse.json({ error: "Unable to refresh" }, { status: 400 });
+  return NextResponse.json(token);
+}

--- a/src/app/api/spotify/top-artists/route.ts
+++ b/src/app/api/spotify/top-artists/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest } from "next/server";
+import { respondWithSpotify, mockTopArtists } from "@/lib/spotify/routes";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const range = req.nextUrl.searchParams.get("time_range") ?? "short_term";
+  return respondWithSpotify(`/me/top/artists?limit=10&time_range=${range}`, mockTopArtists());
+}

--- a/src/app/api/spotify/top-tracks/route.ts
+++ b/src/app/api/spotify/top-tracks/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest } from "next/server";
+import { respondWithSpotify, mockTopTracks } from "@/lib/spotify/routes";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const range = req.nextUrl.searchParams.get("time_range") ?? "short_term";
+  return respondWithSpotify(`/me/top/tracks?limit=10&time_range=${range}`, mockTopTracks());
+}

--- a/src/app/api/spotify/track-analysis/route.ts
+++ b/src/app/api/spotify/track-analysis/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest } from "next/server";
+import { respondWithSpotify, mockAnalysis } from "@/lib/spotify/routes";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const id = req.nextUrl.searchParams.get("id");
+  if (!id) {
+    return Response.json({ error: "Missing id" }, { status: 400 });
+  }
+  return respondWithSpotify(`/audio-analysis/${id}`, mockAnalysis);
+}

--- a/src/app/landing/index.tsx
+++ b/src/app/landing/index.tsx
@@ -13,6 +13,7 @@ import Projects from "@/components/Projects";
 import Contacts from "@/components/Contacts";
 import Recommendations from "@/components/Recommendation";
 import RecentActivitiesPreview from "@/components/Sports/RecentActivitiesPreview";
+import SpotifyOverview from "@/components/Spotify/SpotifyOverview";
 
 // --- Static metadata (replaces react-helmet) ---
 // export const metadata: Metadata = {
@@ -42,6 +43,7 @@ export default function Home() {
             <Skills />
             <Projects colors={theme} />
             <Recommendations />
+            <SpotifyOverview />
             <RecentActivitiesPreview />
             <Contacts colors={theme} />
             {/* <Galaxy />

--- a/src/app/music/page.tsx
+++ b/src/app/music/page.tsx
@@ -1,0 +1,38 @@
+import AudioFeatureRadar from "@/components/Spotify/AudioFeatureRadar";
+import NowPlayingCard from "@/components/Spotify/NowPlayingCard";
+import PlaylistSpotlight from "@/components/Spotify/PlaylistSpotlight";
+import RecentlyPlayedList from "@/components/Spotify/RecentlyPlayedList";
+import TopArtistsGrid from "@/components/Spotify/TopArtistsGrid";
+import TopTracksGrid from "@/components/Spotify/TopTracksGrid";
+import { mockAudioFeaturesList } from "@/lib/spotify/routes";
+
+export const metadata = {
+  title: "My Music • Portfolio",
+  description: "Spotify insights, top tracks, playlists, and listening mood.",
+};
+
+export default function MusicPage() {
+  const mockFeatures = mockAudioFeaturesList();
+  return (
+    <main className="mx-auto max-w-6xl px-4 py-12 md:px-6">
+      <section className="space-y-6">
+        <h1 className="text-3xl font-bold text-white">What I&apos;m listening to</h1>
+        <p className="text-slate-300">Live view of my current soundtrack, refreshed regularly.</p>
+        <div className="grid gap-6 md:grid-cols-[1.4fr_1fr]">
+          <NowPlayingCard />
+          <AudioFeatureRadar features={mockFeatures} />
+        </div>
+      </section>
+
+      <section className="mt-10 grid gap-6 lg:grid-cols-2">
+        <TopTracksGrid />
+        <TopArtistsGrid />
+      </section>
+
+      <section className="mt-10 grid gap-6 lg:grid-cols-[1.3fr_1fr]">
+        <PlaylistSpotlight />
+        <RecentlyPlayedList />
+      </section>
+    </main>
+  );
+}

--- a/src/components/Spotify/AudioFeatureRadar.tsx
+++ b/src/components/Spotify/AudioFeatureRadar.tsx
@@ -1,0 +1,52 @@
+import { aggregateAudioFeatures } from "@/lib/spotify/derive";
+import { SpotifyAudioFeatures } from "@/lib/spotify/types";
+
+interface AudioFeatureRadarProps {
+  features: SpotifyAudioFeatures[];
+}
+
+const metrics: (keyof SpotifyAudioFeatures)[] = [
+  "danceability",
+  "energy",
+  "speechiness",
+  "acousticness",
+  "instrumentalness",
+  "liveness",
+  "valence",
+];
+
+export default function AudioFeatureRadar({ features }: AudioFeatureRadarProps) {
+  const aggregated = aggregateAudioFeatures(features);
+  const points = metrics
+    .map((key, index) => {
+      const angle = (Math.PI * 2 * index) / metrics.length;
+      const radius = (aggregated[key] ?? 0) * 60;
+      const x = 80 + radius * Math.cos(angle);
+      const y = 80 + radius * Math.sin(angle);
+      return `${x},${y}`;
+    })
+    .join(" ");
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/5 p-4 backdrop-blur-sm">
+      <h3 className="text-lg font-semibold text-white">Audio Profile</h3>
+      <div className="mt-4 flex items-center gap-4">
+        <svg viewBox="0 0 160 160" role="img" aria-label="Radar chart of audio features" className="h-48 w-48">
+          <polygon points={points} className="fill-[#89d3ce]/40 stroke-[#1DB954]" strokeWidth={1.5} />
+          <circle cx="80" cy="80" r="60" className="fill-transparent stroke-white/10" />
+        </svg>
+        <div className="space-y-1 text-sm text-slate-300">
+          {metrics.map((key) => (
+            <div key={key} className="flex justify-between gap-4">
+              <span className="capitalize">{key}</span>
+              <span>{aggregated[key].toFixed(2)}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+      <p className="sr-only">
+        Audio features summary: {metrics.map((metric) => `${metric} ${aggregated[metric].toFixed(2)}`).join(", ")}.
+      </p>
+    </div>
+  );
+}

--- a/src/components/Spotify/MoodBadge.tsx
+++ b/src/components/Spotify/MoodBadge.tsx
@@ -1,0 +1,20 @@
+interface MoodBadgeProps {
+  mood: string;
+}
+
+const moodStyles: Record<string, string> = {
+  Upbeat: "bg-[#1DB954]/20 text-[#1DB954]",
+  Chill: "bg-sky-900/50 text-sky-200",
+  Warm: "bg-amber-900/40 text-amber-200",
+  Intense: "bg-rose-900/50 text-rose-200",
+  Somber: "bg-slate-800 text-slate-200",
+};
+
+export default function MoodBadge({ mood }: MoodBadgeProps) {
+  const style = moodStyles[mood] ?? moodStyles.Chill;
+  return (
+    <span className={`rounded-full px-3 py-1 text-xs font-semibold shadow-inner ${style}`} aria-label={`Mood: ${mood}`}>
+      {mood}
+    </span>
+  );
+}

--- a/src/components/Spotify/NowPlayingCard.tsx
+++ b/src/components/Spotify/NowPlayingCard.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+import { FaExternalLinkAlt } from "react-icons/fa";
+import { useSpotifyData } from "@/hooks/useSpotifyData";
+import { mockNowPlaying } from "@/data/spotify-mock";
+import { SpotifyNowPlaying } from "@/lib/spotify/types";
+import { formatDuration } from "@/lib/spotify/derive";
+
+export default function NowPlayingCard() {
+  const { data, isLoading } = useSpotifyData<SpotifyNowPlaying>("/api/spotify/now-playing", {
+    refreshInterval: 20_000,
+  });
+
+  const nowPlaying = data ?? mockNowPlaying;
+  const isLive = nowPlaying.is_playing && nowPlaying.item;
+  const item = nowPlaying.item ?? mockNowPlaying.item;
+
+  const progressPercent = useMemo(() => {
+    if (!nowPlaying.progress_ms || !item) return 0;
+    return Math.min(100, (nowPlaying.progress_ms / item.duration_ms) * 100);
+  }, [item, nowPlaying.progress_ms]);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.style.setProperty("--spotify-progress", `${progressPercent}%`);
+  }, [progressPercent]);
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/5 p-4 backdrop-blur-sm hover:bg-white/[0.06]" aria-live="polite">
+      <div className="flex items-center gap-3">
+        {item?.album?.images?.[0]?.url ? (
+          <img
+            src={item.album.images[0].url}
+            alt={`Album art for ${item.name}`}
+            className="h-16 w-16 rounded-xl object-cover"
+          />
+        ) : (
+          <div className="h-16 w-16 rounded-xl bg-slate-800" aria-hidden />
+        )}
+        <div className="min-w-0">
+          <p className="text-sm text-slate-300">{isLive ? "Now playing" : "Recently played"}</p>
+          <h3 className="truncate text-lg font-semibold text-white">{item?.name ?? "Unknown track"}</h3>
+          <p className="truncate text-slate-400 text-sm">
+            {item?.artists?.map((artist) => artist.name).join(", ") ?? "Unknown artist"}
+          </p>
+        </div>
+        {item?.external_urls?.spotify ? (
+          <a
+            href={item.external_urls.spotify}
+            aria-label="Open in Spotify"
+            target="_blank"
+            rel="noreferrer"
+            className="ml-auto text-[#1DB954] transition hover:text-[#89d3ce] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#89d3ce]"
+          >
+            <FaExternalLinkAlt />
+          </a>
+        ) : null}
+      </div>
+
+      <div className="mt-4">
+        <div className="flex items-center justify-between text-xs text-slate-400">
+          <span>{formatDuration(nowPlaying.progress_ms ?? 0)}</span>
+          <span>{formatDuration(item?.duration_ms ?? 0)}</span>
+        </div>
+        <div className="relative mt-2 h-2 rounded-full bg-white/10">
+          <div
+            className="absolute left-0 top-0 h-full rounded-full bg-gradient-to-r from-[#1DB954] to-[#89d3ce]"
+            style={{ width: `${progressPercent}%`, transition: isLoading ? "none" : "width 0.5s ease" }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Spotify/PlaylistSpotlight.tsx
+++ b/src/components/Spotify/PlaylistSpotlight.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useSpotifyData } from "@/hooks/useSpotifyData";
+import { mockPlaylistList } from "@/lib/spotify/routes";
+import { dominantColorFromImage } from "@/lib/spotify/derive";
+import { SpotifyPlaylist } from "@/lib/spotify/types";
+
+interface PlaylistSpotlightProps {
+  playlistIds?: string[];
+}
+
+export default function PlaylistSpotlight({ playlistIds }: PlaylistSpotlightProps) {
+  const query = playlistIds?.length ? `?id=${playlistIds[0]}` : "";
+  const { data } = useSpotifyData<SpotifyPlaylist | SpotifyPlaylist[]>(`/api/spotify/playlist${query}`);
+
+  const playlists = Array.isArray(data) ? data : data ? [data] : mockPlaylistList();
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/5 p-4 backdrop-blur-sm">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold text-white">Playlist Spotlight</h3>
+        <span className="rounded-full bg-white/5 px-2 py-1 text-xs text-[#1DB954]">Spotify</span>
+      </div>
+      <div className="mt-4 grid gap-4 md:grid-cols-2">
+        {playlists.map((playlist) => {
+          const cover = playlist.images?.[0]?.url ?? "/placeholder.png";
+          const stripe = dominantColorFromImage(cover);
+          return (
+            <article key={playlist.id} className="rounded-xl border border-white/5 bg-white/5 p-3 hover:bg-white/10">
+              <div className="flex gap-3">
+                <img src={cover} alt={`Cover of ${playlist.name}`} className="h-16 w-16 rounded-xl object-cover" />
+                <div className="min-w-0">
+                  <p className="text-sm font-semibold text-white">{playlist.name}</p>
+                  <p className="text-xs text-slate-400">{playlist.description ?? "Curated vibes"}</p>
+                  <p className="text-xs text-slate-500">{playlist.tracks?.total ?? 0} tracks</p>
+                </div>
+              </div>
+              <div className="mt-3 h-1 rounded-full" style={{ background: stripe }} aria-hidden />
+            </article>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Spotify/RecentlyPlayedList.tsx
+++ b/src/components/Spotify/RecentlyPlayedList.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useSpotifyData } from "@/hooks/useSpotifyData";
+import { mockRecentlyPlayed } from "@/lib/spotify/routes";
+import { formatDuration } from "@/lib/spotify/derive";
+
+export default function RecentlyPlayedList() {
+  const { data, isLoading } = useSpotifyData<{ items: { track: any; played_at: string }[] }>(
+    "/api/spotify/recently-played",
+  );
+  const items = data?.items ?? mockRecentlyPlayed.items;
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/5 p-4 backdrop-blur-sm">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold text-white">Recently Played</h3>
+        {isLoading && <span className="text-xs text-slate-400">Refreshing...</span>}
+      </div>
+      <ul className="mt-4 space-y-3">
+        {items.map(({ track, played_at }) => (
+          <li key={`${track.id}-${played_at}`} className="flex items-center gap-3 rounded-xl border border-white/5 p-3">
+            <img
+              src={track.album.images?.[0]?.url ?? "/placeholder.png"}
+              alt={`Album art for ${track.name}`}
+              className="h-12 w-12 rounded-lg object-cover"
+            />
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-medium text-white">{track.name}</p>
+              <p className="truncate text-xs text-slate-400">{track.artists.map((a: any) => a.name).join(", ")}</p>
+              <p className="text-xs text-slate-500">{new Date(played_at).toLocaleString()}</p>
+            </div>
+            <p className="text-xs text-slate-400">{formatDuration(track.duration_ms)}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/Spotify/SpotifyOverview.tsx
+++ b/src/components/Spotify/SpotifyOverview.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import AudioFeatureRadar from "./AudioFeatureRadar";
+import MoodBadge from "./MoodBadge";
+import NowPlayingCard from "./NowPlayingCard";
+import PlaylistSpotlight from "./PlaylistSpotlight";
+import { mockAudioFeaturesList } from "@/lib/spotify/routes";
+import { aggregateAudioFeatures, moodFromFeatures } from "@/lib/spotify/derive";
+import { mockTracks } from "@/data/spotify-mock";
+
+export default function SpotifyOverview() {
+  const features = mockAudioFeaturesList();
+  const aggregate = aggregateAudioFeatures(features);
+  const mood = moodFromFeatures(aggregate.valence, aggregate.energy);
+
+  return (
+    <section aria-label="Spotify overview" className="mt-16">
+      <div className="mx-auto max-w-6xl rounded-3xl border border-white/10 bg-white/5 p-6 shadow-xl backdrop-blur">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <p className="text-sm uppercase tracking-wide text-[#89d3ce]">Music</p>
+            <h2 className="text-2xl font-bold text-white">What I&apos;m Listening To</h2>
+            <p className="text-slate-300">Live snapshot of my current soundtrack and mood.</p>
+          </div>
+          <MoodBadge mood={mood} />
+        </div>
+        <div className="mt-6 grid gap-6 md:grid-cols-[1.2fr_1fr]">
+          <NowPlayingCard />
+          <div className="space-y-4 rounded-2xl border border-white/10 bg-white/5 p-4">
+            <h3 className="text-lg font-semibold text-white">Current favorites</h3>
+            <ul className="space-y-3">
+              {mockTracks.slice(0, 5).map((track) => (
+                <li key={track.id} className="flex items-center gap-3">
+                  <img
+                    src={track.album.images?.[0]?.url ?? "/placeholder.png"}
+                    alt={`Album art for ${track.name}`}
+                    className="h-10 w-10 rounded-lg object-cover"
+                  />
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium text-white">{track.name}</p>
+                    <p className="truncate text-xs text-slate-400">{track.artists.map((a) => a.name).join(", ")}</p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+        <div className="mt-6 grid gap-4 md:grid-cols-[1.2fr_1fr]">
+          <PlaylistSpotlight />
+          <AudioFeatureRadar features={features} />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Spotify/TopArtistsGrid.tsx
+++ b/src/components/Spotify/TopArtistsGrid.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState } from "react";
+import { useSpotifyData } from "@/hooks/useSpotifyData";
+import { mockTopArtists } from "@/lib/spotify/routes";
+import { SpotifyArtist, SpotifyTimeRange } from "@/lib/spotify/types";
+
+const ranges: { label: string; value: SpotifyTimeRange }[] = [
+  { label: "Now", value: "short_term" },
+  { label: "Season", value: "medium_term" },
+  { label: "All time", value: "long_term" },
+];
+
+export default function TopArtistsGrid() {
+  const [range, setRange] = useState<SpotifyTimeRange>("short_term");
+  const { data, isLoading } = useSpotifyData<SpotifyArtist[]>(`/api/spotify/top-artists?time_range=${range}`);
+  const artists = data ?? mockTopArtists();
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/5 p-4 backdrop-blur-sm">
+      <div className="flex items-center justify-between gap-4">
+        <h3 className="text-lg font-semibold text-white">Top Artists</h3>
+        <div className="flex items-center gap-2" role="tablist" aria-label="Top artists range">
+          {ranges.map((option) => (
+            <button
+              key={option.value}
+              role="tab"
+              aria-selected={range === option.value}
+              onClick={() => setRange(option.value)}
+              className={`rounded-full px-3 py-1 text-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#89d3ce] ${range === option.value ? "bg-white/10 text-white" : "text-slate-300 hover:text-white"}`}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="mt-4 grid gap-3 sm:grid-cols-2 md:grid-cols-3">
+        {artists.map((artist) => (
+          <article key={artist.id} className="rounded-xl border border-white/5 bg-white/5 p-3 hover:bg-white/10">
+            <div className="flex items-center gap-3">
+              {artist.images?.[0]?.url ? (
+                <img
+                  src={artist.images[0].url}
+                  alt={`Portrait of ${artist.name}`}
+                  className="h-14 w-14 rounded-full object-cover"
+                />
+              ) : (
+                <div className="h-14 w-14 rounded-full bg-slate-800" aria-hidden />
+              )}
+              <div className="min-w-0">
+                <p className="truncate text-sm font-semibold text-white">{artist.name}</p>
+                <p className="text-xs text-slate-400">{artist.genres?.slice(0, 2).join(", ") ?? "Artist"}</p>
+              </div>
+            </div>
+          </article>
+        ))}
+        {isLoading && <p className="text-sm text-slate-400">Loading...</p>}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Spotify/TopTracksGrid.tsx
+++ b/src/components/Spotify/TopTracksGrid.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useState } from "react";
+import { useSpotifyData } from "@/hooks/useSpotifyData";
+import { mockTopTracks } from "@/lib/spotify/routes";
+import { SpotifyTrack, SpotifyTimeRange } from "@/lib/spotify/types";
+import MoodBadge from "./MoodBadge";
+import { formatDuration, moodFromFeatures } from "@/lib/spotify/derive";
+
+const ranges: { label: string; value: SpotifyTimeRange }[] = [
+  { label: "Now", value: "short_term" },
+  { label: "Season", value: "medium_term" },
+  { label: "All time", value: "long_term" },
+];
+
+export default function TopTracksGrid() {
+  const [range, setRange] = useState<SpotifyTimeRange>("short_term");
+  const { data, isLoading } = useSpotifyData<SpotifyTrack[]>(`/api/spotify/top-tracks?time_range=${range}`);
+  const tracks = data ?? mockTopTracks();
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/5 p-4 backdrop-blur-sm">
+      <div className="flex items-center justify-between gap-4">
+        <h3 className="text-lg font-semibold text-white">Top Tracks</h3>
+        <div className="flex items-center gap-2" role="tablist" aria-label="Top tracks range">
+          {ranges.map((option) => (
+            <button
+              key={option.value}
+              role="tab"
+              aria-selected={range === option.value}
+              onClick={() => setRange(option.value)}
+              className={`rounded-full px-3 py-1 text-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#89d3ce] ${range === option.value ? "bg-white/10 text-white" : "text-slate-300 hover:text-white"}`}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="mt-4 grid gap-3 md:grid-cols-2">
+        {tracks.map((track) => (
+          <article
+            key={track.id}
+            className="flex items-center gap-3 rounded-xl border border-white/5 bg-white/5 p-3 hover:bg-white/10"
+          >
+            <img
+              src={track.album.images?.[0]?.url ?? "/placeholder.png"}
+              alt={`Album art for ${track.name}`}
+              className="h-14 w-14 rounded-xl object-cover"
+            />
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-medium text-white">{track.name}</p>
+              <p className="truncate text-xs text-slate-400">
+                {track.artists.map((artist) => artist.name).join(", ")}
+              </p>
+              <p className="text-xs text-slate-400">{formatDuration(track.duration_ms)}</p>
+            </div>
+            <MoodBadge mood={moodFromFeatures(0.6, 0.6)} />
+          </article>
+        ))}
+        {isLoading && <p className="text-sm text-slate-400">Loading...</p>}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Spotify/TrackDetailDrawer.tsx
+++ b/src/components/Spotify/TrackDetailDrawer.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import TrackDetailModal from "./TrackDetailModal";
+
+interface TrackDetailDrawerProps {
+  trackId: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function TrackDetailDrawer({ trackId, open, onClose }: TrackDetailDrawerProps) {
+  if (!open) return null;
+  return <TrackDetailModal trackId={trackId} onClose={onClose} />;
+}

--- a/src/components/Spotify/TrackDetailModal.tsx
+++ b/src/components/Spotify/TrackDetailModal.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { tagFromFeatures } from "@/lib/spotify/derive";
+import { useSpotifyData } from "@/hooks/useSpotifyData";
+import { SpotifyAudioFeatures, SpotifyTrackAnalysis } from "@/lib/spotify/types";
+
+interface TrackDetailModalProps {
+  trackId: string;
+  onClose: () => void;
+}
+
+export default function TrackDetailModal({ trackId, onClose }: TrackDetailModalProps) {
+  const { data: analysis } = useSpotifyData<SpotifyTrackAnalysis>(`/api/spotify/track-analysis?id=${trackId}`);
+  const { data: features } = useSpotifyData<SpotifyAudioFeatures>(`/api/spotify/audio-features?ids=${trackId}`);
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => setIsMounted(true), []);
+
+  if (!isMounted) return null;
+
+  const tags = features ? tagFromFeatures(features) : [];
+  const handleKey = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape") onClose();
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      onKeyDown={handleKey}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+    >
+      <div className="w-full max-w-lg rounded-2xl border border-white/10 bg-white/5 p-6" tabIndex={-1}>
+        <div className="flex items-center justify-between">
+          <h3 className="text-xl font-semibold text-white">Track Details</h3>
+          <button
+            onClick={onClose}
+            aria-label="Close track details"
+            className="rounded-full px-3 py-1 text-sm text-slate-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#89d3ce]"
+          >
+            Close
+          </button>
+        </div>
+        <p className="mt-2 text-sm text-slate-300">Sections: {analysis?.sections?.length ?? 0}</p>
+        <p className="text-sm text-slate-300">Tempo: {analysis?.sections?.[0]?.tempo ?? 0} BPM</p>
+        <div className="mt-3 flex flex-wrap gap-2">
+          {tags.map((tag) => (
+            <span key={tag} className="rounded-full bg-white/10 px-2 py-1 text-xs text-slate-200">
+              {tag}
+            </span>
+          ))}
+        </div>
+        <p className="sr-only">Track modal can be closed with escape key.</p>
+      </div>
+    </div>
+  );
+}

--- a/src/data/projectsData.ts
+++ b/src/data/projectsData.ts
@@ -95,7 +95,7 @@ export const projectsData: Project[] = [
     code: "https://github.com/AshifAli007/HackFSU-SPR24",
   },
   {
-    id: 9,
+    id: 10,
     projectName: "Particles",
     projectDesc:
       "Created using css and javascript. Move mouse to create enlarged particles around the mouse.",

--- a/src/data/spotify-mock.ts
+++ b/src/data/spotify-mock.ts
@@ -1,0 +1,46 @@
+import { SpotifyAudioFeatures, SpotifyNowPlaying, SpotifyPlaylist, SpotifyTrack } from "@/lib/spotify/types";
+
+export const mockTrack: SpotifyTrack = {
+  id: "mock-track",
+  name: "Midnight Drive",
+  duration_ms: 210000,
+  external_urls: { spotify: "https://spotify.com" },
+  album: {
+    id: "mock-album",
+    name: "City Lights",
+    images: [{ url: "/placeholder.png", height: 640, width: 640 }],
+  },
+  artists: [{ id: "artist-1", name: "Lumen" }],
+};
+
+export const mockTracks: SpotifyTrack[] = Array.from({ length: 5 }).map((_, idx) => ({
+  ...mockTrack,
+  id: `mock-track-${idx}`,
+  name: `${mockTrack.name} ${idx + 1}`,
+}));
+
+export const mockFeatures: SpotifyAudioFeatures = {
+  danceability: 0.72,
+  energy: 0.65,
+  speechiness: 0.08,
+  acousticness: 0.12,
+  instrumentalness: 0.0,
+  liveness: 0.15,
+  valence: 0.62,
+  tempo: 118,
+};
+
+export const mockNowPlaying: SpotifyNowPlaying = {
+  is_playing: false,
+  progress_ms: 0,
+  item: mockTrack,
+};
+
+export const mockPlaylist: SpotifyPlaylist = {
+  id: "mock-playlist",
+  name: "Focus Flow",
+  description: "A curated set of tracks to stay in flow.",
+  tracks: { total: 24 },
+  images: [{ url: "/placeholder.png" }],
+  external_urls: { spotify: "https://spotify.com" },
+};

--- a/src/hooks/useSpotifyData.ts
+++ b/src/hooks/useSpotifyData.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+
+export function useSpotifyData<T>(endpoint: string, options?: { refreshInterval?: number }) {
+  const [data, setData] = useState<T | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  useEffect(() => {
+    let active = true;
+    let timer: NodeJS.Timeout;
+
+    const fetchData = async () => {
+      setIsLoading(true);
+      try {
+        const res = await fetch(endpoint, { cache: "no-store" });
+        if (!res.ok) throw new Error("Failed to fetch Spotify data");
+        const json = (await res.json()) as T;
+        if (active) setData(json);
+      } catch (err) {
+        if (active) setError(err as Error);
+      } finally {
+        if (active) setIsLoading(false);
+      }
+    };
+
+    fetchData();
+
+    if (options?.refreshInterval) {
+      timer = setInterval(fetchData, options.refreshInterval);
+    }
+
+    return () => {
+      active = false;
+      if (timer) clearInterval(timer);
+    };
+  }, [endpoint, options?.refreshInterval]);
+
+  return { data, error, isLoading };
+}

--- a/src/lib/spotify/auth.ts
+++ b/src/lib/spotify/auth.ts
@@ -1,0 +1,79 @@
+import { NextRequest } from "next/server";
+import { getSpotifyConfig, hasSpotifyEnv } from "./config";
+
+const SPOTIFY_AUTH_URL = "https://accounts.spotify.com/authorize";
+const SPOTIFY_TOKEN_URL = "https://accounts.spotify.com/api/token";
+
+let refreshTokenStore: string | null = null;
+
+export function buildAuthUrl(state: string, scopes?: string[]): string {
+  if (!hasSpotifyEnv()) return "";
+  const { clientId, redirectUri } = getSpotifyConfig();
+  const params = new URLSearchParams({
+    response_type: "code",
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    scope: scopes?.join(" ") ?? "user-read-playback-state user-top-read user-read-recently-played playlist-read-private",
+    state,
+  });
+  return `${SPOTIFY_AUTH_URL}?${params.toString()}`;
+}
+
+export async function exchangeCodeForToken(code: string): Promise<{ access_token: string; refresh_token?: string; expires_in: number } | null> {
+  if (!hasSpotifyEnv()) return null;
+  const { clientId, clientSecret, redirectUri } = getSpotifyConfig();
+  const body = new URLSearchParams({
+    grant_type: "authorization_code",
+    code,
+    redirect_uri: redirectUri,
+  });
+  const token = await fetchToken(body, clientId, clientSecret);
+  if (token?.refresh_token) {
+    refreshTokenStore = token.refresh_token;
+  }
+  return token;
+}
+
+export async function refreshAccessToken(existing?: string): Promise<{ access_token: string; expires_in: number } | null> {
+  if (!hasSpotifyEnv()) return null;
+  const { clientId, clientSecret } = getSpotifyConfig();
+  const refreshToken = existing ?? refreshTokenStore;
+  if (!refreshToken) return null;
+  const body = new URLSearchParams({
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+  });
+  return fetchToken(body, clientId, clientSecret);
+}
+
+async function fetchToken(body: URLSearchParams, clientId: string, clientSecret: string) {
+  const basic = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
+  const response = await fetch(SPOTIFY_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${basic}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body,
+  });
+  if (!response.ok) {
+    return null;
+  }
+  return (await response.json()) as {
+    access_token: string;
+    refresh_token?: string;
+    expires_in: number;
+  };
+}
+
+export function readStateFromRequest(req: NextRequest): string {
+  return req.nextUrl.searchParams.get("state") ?? "";
+}
+
+export function getRefreshToken(): string | null {
+  return refreshTokenStore;
+}
+
+export function setRefreshToken(token: string): void {
+  refreshTokenStore = token;
+}

--- a/src/lib/spotify/cache.ts
+++ b/src/lib/spotify/cache.ts
@@ -1,0 +1,24 @@
+const cache = new Map<string, { expires: number; value: unknown }>();
+
+export function setCached<T>(key: string, value: T, ttlMs: number): T {
+  cache.set(key, { value, expires: Date.now() + ttlMs });
+  return value;
+}
+
+export function getCached<T>(key: string): T | null {
+  const entry = cache.get(key);
+  if (!entry) return null;
+  if (Date.now() > entry.expires) {
+    cache.delete(key);
+    return null;
+  }
+  return entry.value as T;
+}
+
+export function clearCache(key?: string): void {
+  if (key) {
+    cache.delete(key);
+  } else {
+    cache.clear();
+  }
+}

--- a/src/lib/spotify/config.ts
+++ b/src/lib/spotify/config.ts
@@ -1,12 +1,8 @@
 import { SpotifyConfig } from "./types";
 
-const requiredVars = [
-  "SPOTIFY_CLIENT_ID",
-  "SPOTIFY_CLIENT_SECRET",
-  "SPOTIFY_REDIRECT_URI",
-  "SPOTIFY_PLAYLIST_IDS",
-  "ENCRYPTION_KEY",
-] as const;
+const clientCredentialVars = ["SPOTIFY_CLIENT_ID", "SPOTIFY_CLIENT_SECRET"] as const;
+
+const requiredVars = [...clientCredentialVars, "SPOTIFY_REDIRECT_URI", "SPOTIFY_PLAYLIST_IDS", "ENCRYPTION_KEY"] as const;
 
 type EnvKey = (typeof requiredVars)[number];
 
@@ -30,4 +26,15 @@ export function getSpotifyConfig(): SpotifyConfig {
 
 export function hasSpotifyEnv(): boolean {
   return requiredVars.every((key) => Boolean(process.env[key]));
+}
+
+export function hasSpotifyClientCredentialsEnv(): boolean {
+  return clientCredentialVars.every((key) => Boolean(process.env[key]));
+}
+
+export function getSpotifyClientCredentials(): Pick<SpotifyConfig, "clientId" | "clientSecret"> {
+  return {
+    clientId: readEnv("SPOTIFY_CLIENT_ID"),
+    clientSecret: readEnv("SPOTIFY_CLIENT_SECRET"),
+  };
 }

--- a/src/lib/spotify/config.ts
+++ b/src/lib/spotify/config.ts
@@ -1,0 +1,33 @@
+import { SpotifyConfig } from "./types";
+
+const requiredVars = [
+  "SPOTIFY_CLIENT_ID",
+  "SPOTIFY_CLIENT_SECRET",
+  "SPOTIFY_REDIRECT_URI",
+  "SPOTIFY_PLAYLIST_IDS",
+  "ENCRYPTION_KEY",
+] as const;
+
+type EnvKey = (typeof requiredVars)[number];
+
+function readEnv(key: EnvKey): string {
+  const value = process.env[key];
+  if (!value || value.length === 0) {
+    throw new Error(`Missing required environment variable: ${key}`);
+  }
+  return value;
+}
+
+export function getSpotifyConfig(): SpotifyConfig {
+  return {
+    clientId: readEnv("SPOTIFY_CLIENT_ID"),
+    clientSecret: readEnv("SPOTIFY_CLIENT_SECRET"),
+    redirectUri: readEnv("SPOTIFY_REDIRECT_URI"),
+    playlistIds: readEnv("SPOTIFY_PLAYLIST_IDS").split(",").map((id) => id.trim()),
+    encryptionKey: readEnv("ENCRYPTION_KEY"),
+  };
+}
+
+export function hasSpotifyEnv(): boolean {
+  return requiredVars.every((key) => Boolean(process.env[key]));
+}

--- a/src/lib/spotify/derive.ts
+++ b/src/lib/spotify/derive.ts
@@ -1,0 +1,76 @@
+import { SpotifyAudioFeatures, SpotifyTrack } from "./types";
+
+export function moodFromFeatures(valence: number, energy: number): string {
+  if (valence > 0.7 && energy > 0.6) return "Upbeat";
+  if (valence > 0.6 && energy <= 0.6) return "Warm";
+  if (valence < 0.4 && energy > 0.6) return "Intense";
+  if (valence < 0.4 && energy < 0.4) return "Somber";
+  return "Chill";
+}
+
+export function tagFromFeatures(features: SpotifyAudioFeatures): string[] {
+  const tags: string[] = [];
+  if (features.energy > 0.7) tags.push("High Energy");
+  if (features.danceability > 0.7) tags.push("Danceable");
+  if (features.acousticness > 0.5) tags.push("Acoustic");
+  if (features.instrumentalness > 0.5) tags.push("Instrumental");
+  if (features.speechiness > 0.4) tags.push("Spoken Word");
+  if (features.valence > 0.6) tags.push("Positive");
+  return tags.length ? tags : ["Balanced"];
+}
+
+export function aggregateAudioFeatures(tracks: SpotifyAudioFeatures[]): SpotifyAudioFeatures {
+  const count = tracks.length || 1;
+  const totals = tracks.reduce(
+    (acc, track) => {
+      acc.danceability += track.danceability;
+      acc.energy += track.energy;
+      acc.speechiness += track.speechiness;
+      acc.acousticness += track.acousticness;
+      acc.instrumentalness += track.instrumentalness;
+      acc.liveness += track.liveness;
+      acc.valence += track.valence;
+      acc.tempo += track.tempo;
+      return acc;
+    },
+    {
+      danceability: 0,
+      energy: 0,
+      speechiness: 0,
+      acousticness: 0,
+      instrumentalness: 0,
+      liveness: 0,
+      valence: 0,
+      tempo: 0,
+    },
+  );
+
+  return {
+    danceability: totals.danceability / count,
+    energy: totals.energy / count,
+    speechiness: totals.speechiness / count,
+    acousticness: totals.acousticness / count,
+    instrumentalness: totals.instrumentalness / count,
+    liveness: totals.liveness / count,
+    valence: totals.valence / count,
+    tempo: totals.tempo / count,
+  };
+}
+
+export function dominantColorFromImage(_url?: string): string {
+  return "#1DB954";
+}
+
+export function formatDuration(durationMs: number): string {
+  const minutes = Math.floor(durationMs / 60000);
+  const seconds = Math.floor((durationMs % 60000) / 1000)
+    .toString()
+    .padStart(2, "0");
+  return `${minutes}:${seconds}`;
+}
+
+export function averageMoodFromTracks(tracks: SpotifyTrack[], features: SpotifyAudioFeatures[]): string {
+  if (!tracks.length || !features.length) return "Chill";
+  const aggregate = aggregateAudioFeatures(features);
+  return moodFromFeatures(aggregate.valence, aggregate.energy);
+}

--- a/src/lib/spotify/fetch.ts
+++ b/src/lib/spotify/fetch.ts
@@ -1,6 +1,6 @@
-import { refreshAccessToken } from "./auth";
+import { getClientCredentialsAccessToken, refreshAccessToken } from "./auth";
 import { getCached, setCached } from "./cache";
-import { hasSpotifyEnv } from "./config";
+import { hasSpotifyClientCredentialsEnv, hasSpotifyEnv } from "./config";
 
 const API_BASE = "https://api.spotify.com/v1";
 const RETRY_LIMIT = 3;
@@ -16,24 +16,47 @@ async function backoff(delay: number) {
   return new Promise((resolve) => setTimeout(resolve, delay));
 }
 
+function needsUserToken(endpoint: string): boolean {
+  return endpoint.startsWith("/me");
+}
+
 async function withAuthFetch<T>(endpoint: string, accessToken?: string, attempt = 0): Promise<T> {
-  if (!hasSpotifyEnv()) {
+  const hasSpotifyConfig = hasSpotifyEnv() || hasSpotifyClientCredentialsEnv();
+  if (!hasSpotifyConfig) {
     throw new Error("Spotify environment not configured");
   }
   const cacheKey = `${endpoint}`;
   const cached = getCached<T>(cacheKey);
   if (cached) return cached;
-
-  const token = accessToken ?? process.env.SPOTIFY_ACCESS_TOKEN;
+  console.log(`Fetching Spotify endpoint: ${endpoint}, attempt: ${attempt + 1}`);
+  let token =
+    accessToken ??
+    process.env.SPOTIFY_ACCESS_TOKEN ??
+    (!needsUserToken(endpoint) ? await getClientCredentialsAccessToken() : undefined);
+  if (!token && needsUserToken(endpoint)) {
+    const refreshed = await refreshAccessToken();
+    token = refreshed?.access_token;
+  }
+  if (!token) {
+    throw new Error(needsUserToken(endpoint) ? "Spotify user access token missing" : "Spotify access token missing");
+  }
   const response = await fetch(`${API_BASE}${endpoint}`, {
     headers: { Authorization: `Bearer ${token}` },
     cache: "no-store",
   });
 
   if (response.status === 401 && attempt < RETRY_LIMIT) {
-    const refreshed = await refreshAccessToken();
-    if (refreshed?.access_token) {
-      return withAuthFetch<T>(endpoint, refreshed.access_token, attempt + 1);
+    if (needsUserToken(endpoint)) {
+      const refreshed = await refreshAccessToken();
+      if (refreshed?.access_token) {
+        return withAuthFetch<T>(endpoint, refreshed.access_token, attempt + 1);
+      }
+    }
+    if (!needsUserToken(endpoint)) {
+      const clientCredentialsToken = await getClientCredentialsAccessToken(true);
+      if (clientCredentialsToken) {
+        return withAuthFetch<T>(endpoint, clientCredentialsToken, attempt + 1);
+      }
     }
   }
 
@@ -41,6 +64,11 @@ async function withAuthFetch<T>(endpoint: string, accessToken?: string, attempt 
     const retryAfter = Number(response.headers.get("Retry-After")) || (attempt + 1) * 500;
     await backoff(retryAfter * (attempt + 1));
     return withAuthFetch<T>(endpoint, accessToken, attempt + 1);
+  }
+
+  if (!response.ok && endpoint === "/me/player/currently-playing" && (response.status === 204 || response.status === 404)) {
+    const empty = { is_playing: false, item: null } as T;
+    return setCached(cacheKey, empty, DEFAULT_TTL[endpoint] ?? 20_000);
   }
 
   if (!response.ok) {

--- a/src/lib/spotify/fetch.ts
+++ b/src/lib/spotify/fetch.ts
@@ -1,0 +1,57 @@
+import { refreshAccessToken } from "./auth";
+import { getCached, setCached } from "./cache";
+import { hasSpotifyEnv } from "./config";
+
+const API_BASE = "https://api.spotify.com/v1";
+const RETRY_LIMIT = 3;
+
+const DEFAULT_TTL: Record<string, number> = {
+  "/me/player/currently-playing": 20_000,
+  "/me/top/tracks": 30_000,
+  "/me/top/artists": 30_000,
+  "/me/player/recently-played": 45_000,
+};
+
+async function backoff(delay: number) {
+  return new Promise((resolve) => setTimeout(resolve, delay));
+}
+
+async function withAuthFetch<T>(endpoint: string, accessToken?: string, attempt = 0): Promise<T> {
+  if (!hasSpotifyEnv()) {
+    throw new Error("Spotify environment not configured");
+  }
+  const cacheKey = `${endpoint}`;
+  const cached = getCached<T>(cacheKey);
+  if (cached) return cached;
+
+  const token = accessToken ?? process.env.SPOTIFY_ACCESS_TOKEN;
+  const response = await fetch(`${API_BASE}${endpoint}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: "no-store",
+  });
+
+  if (response.status === 401 && attempt < RETRY_LIMIT) {
+    const refreshed = await refreshAccessToken();
+    if (refreshed?.access_token) {
+      return withAuthFetch<T>(endpoint, refreshed.access_token, attempt + 1);
+    }
+  }
+
+  if (response.status === 429 && attempt < RETRY_LIMIT) {
+    const retryAfter = Number(response.headers.get("Retry-After")) || (attempt + 1) * 500;
+    await backoff(retryAfter * (attempt + 1));
+    return withAuthFetch<T>(endpoint, accessToken, attempt + 1);
+  }
+
+  if (!response.ok) {
+    throw new Error(`Spotify request failed: ${response.status}`);
+  }
+
+  const ttl = DEFAULT_TTL[endpoint] ?? 60_000;
+  const data = (await response.json()) as T;
+  return setCached(cacheKey, data, ttl);
+}
+
+export async function spotifyGet<T>(endpoint: string, token?: string) {
+  return withAuthFetch<T>(endpoint, token);
+}

--- a/src/lib/spotify/routes.ts
+++ b/src/lib/spotify/routes.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from "next/server";
 import { mockFeatures, mockNowPlaying, mockPlaylist, mockTrack, mockTracks } from "@/data/spotify-mock";
 import { spotifyGet } from "./fetch";
-import { hasSpotifyEnv } from "./config";
+import { hasSpotifyClientCredentialsEnv, hasSpotifyEnv } from "./config";
 import { SpotifyAudioFeatures, SpotifyNowPlaying, SpotifyPlaylist, SpotifyTrack, SpotifyTrackAnalysis } from "./types";
 
 export async function respondWithSpotify<T>(endpoint: string, mock: T) {
   try {
-    if (!hasSpotifyEnv()) {
+    if (!hasSpotifyEnv() && !hasSpotifyClientCredentialsEnv()) {
       return NextResponse.json(mock, { status: 200 });
     }
     const data = await spotifyGet<T>(endpoint);

--- a/src/lib/spotify/routes.ts
+++ b/src/lib/spotify/routes.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from "next/server";
+import { mockFeatures, mockNowPlaying, mockPlaylist, mockTrack, mockTracks } from "@/data/spotify-mock";
+import { spotifyGet } from "./fetch";
+import { hasSpotifyEnv } from "./config";
+import { SpotifyAudioFeatures, SpotifyNowPlaying, SpotifyPlaylist, SpotifyTrack, SpotifyTrackAnalysis } from "./types";
+
+export async function respondWithSpotify<T>(endpoint: string, mock: T) {
+  try {
+    if (!hasSpotifyEnv()) {
+      return NextResponse.json(mock, { status: 200 });
+    }
+    const data = await spotifyGet<T>(endpoint);
+    return NextResponse.json(data, { status: 200 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(mock, { status: 200 });
+  }
+}
+
+export const mockAnalysis: SpotifyTrackAnalysis = {
+  bars: [],
+  beats: [],
+  sections: [
+    { start: 0, duration: 30, tempo: 120, key: 5 },
+    { start: 30, duration: 45, tempo: 122, key: 5 },
+  ],
+  segments: [],
+  tatums: [],
+};
+
+export function mockAudioFeaturesList(): SpotifyAudioFeatures[] {
+  return Array.from({ length: 5 }).map(() => mockFeatures);
+}
+
+export function mockTopTracks(): SpotifyTrack[] {
+  return mockTracks;
+}
+
+export function mockTopArtists() {
+  return [
+    { id: "artist-1", name: "Lumen", images: [{ url: "/placeholder.png" }] },
+    { id: "artist-2", name: "Echoes", images: [{ url: "/placeholder.png" }] },
+  ];
+}
+
+export function mockPlaylistList(): SpotifyPlaylist[] {
+  return [mockPlaylist];
+}
+
+export const mockRecentlyPlayed = {
+  items: mockTracks.map((track) => ({ track, played_at: new Date().toISOString() })),
+};
+
+export function mockNowPlayingData(): SpotifyNowPlaying {
+  return mockNowPlaying;
+}
+
+export function mockAudioFeatures(): SpotifyAudioFeatures {
+  return mockFeatures;
+}

--- a/src/lib/spotify/types.ts
+++ b/src/lib/spotify/types.ts
@@ -1,0 +1,73 @@
+export type SpotifyImage = {
+  url: string;
+  height?: number | null;
+  width?: number | null;
+};
+
+export type SpotifyArtist = {
+  id: string;
+  name: string;
+  href?: string;
+  external_urls?: { spotify?: string };
+  images?: SpotifyImage[];
+  genres?: string[];
+  followers?: { total: number };
+};
+
+export type SpotifyTrack = {
+  id: string;
+  name: string;
+  duration_ms: number;
+  preview_url?: string | null;
+  external_urls?: { spotify?: string };
+  album: {
+    id: string;
+    name: string;
+    images: SpotifyImage[];
+  };
+  artists: SpotifyArtist[];
+};
+
+export type SpotifyPlaylist = {
+  id: string;
+  name: string;
+  description?: string;
+  tracks?: { total: number };
+  images?: SpotifyImage[];
+  external_urls?: { spotify?: string };
+};
+
+export type SpotifyAudioFeatures = {
+  danceability: number;
+  energy: number;
+  speechiness: number;
+  acousticness: number;
+  instrumentalness: number;
+  liveness: number;
+  valence: number;
+  tempo: number;
+};
+
+export type SpotifyNowPlaying = {
+  is_playing: boolean;
+  progress_ms?: number;
+  item?: SpotifyTrack | null;
+};
+
+export type SpotifyTrackAnalysis = {
+  bars: unknown[];
+  beats: unknown[];
+  sections: { start: number; duration: number; tempo: number; key: number }[];
+  segments: unknown[];
+  tatums: unknown[];
+};
+
+export type SpotifyTimeRange = "short_term" | "medium_term" | "long_term";
+
+export type SpotifyConfig = {
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+  playlistIds: string[];
+  encryptionKey: string;
+};

--- a/src/tests/api-top-tracks.test.ts
+++ b/src/tests/api-top-tracks.test.ts
@@ -1,0 +1,5 @@
+import assert from "node:assert";
+import { mockTopTracks } from "@/lib/spotify/routes";
+
+const tracks = mockTopTracks();
+assert(tracks.length > 0);

--- a/src/tests/spotify.test.ts
+++ b/src/tests/spotify.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert";
+import { aggregateAudioFeatures, moodFromFeatures } from "@/lib/spotify/derive";
+
+const sample = [
+  {
+    danceability: 0.5,
+    energy: 0.5,
+    speechiness: 0.1,
+    acousticness: 0.2,
+    instrumentalness: 0.1,
+    liveness: 0.1,
+    valence: 0.6,
+    tempo: 120,
+  },
+  {
+    danceability: 0.7,
+    energy: 0.7,
+    speechiness: 0.2,
+    acousticness: 0.1,
+    instrumentalness: 0.0,
+    liveness: 0.2,
+    valence: 0.8,
+    tempo: 122,
+  },
+];
+
+const aggregated = aggregateAudioFeatures(sample);
+
+assert(Math.abs(aggregated.tempo - 121) < 0.5);
+assert(moodFromFeatures(0.8, 0.7) === "Upbeat");


### PR DESCRIPTION
## Summary
- add Spotify API route handlers with typed helpers, mock fallbacks, and env-gated config for authorization and data fetching
- build Spotify UI components including now playing card, grids, playlist spotlight, radar chart, and integrate a music page plus homepage section
- add helper utilities for audio feature aggregation and initial test scaffolds

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692230b7e018832fa8506e2be9d10b64)